### PR TITLE
Google Drive API V2 Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,17 +73,20 @@ class ghostGoogleDrive extends StorageBase {
             // make the url looks like a file
             resolve("/content/images/" + data.id + "." + data.fileExtension);
             
-            drive.files.permissions.create({
-              "fileId": data.id,
+            drive.permissions.create({
+              fileId: data.id,
               "resource": {
-                "role": "reader",
-                "type": "anyone"
+                resource: permission,
+                fileId: data.id,
+                fields: 'id',
               }
-            })
-            .then(function(response) {
-              console.log("Response", response);
-            },
-            function(err) { console.error("Execute error", err); });
+            }, function (err, res) {
+              if (err) {
+                console.error(err);
+              } else {
+                console.log('Permission ID: ', res.id)
+              }
+            });
           }
         );
       });

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const fs = require("fs");
 const { google } = require("googleapis");
 const https = require("https");
 
-const API_VERSION = "v3";
+const API_VERSION = "v2";
 const API_SCOPES = ["https://www.googleapis.com/auth/drive"];
 
 class ghostGoogleDrive extends StorageBase {
@@ -52,7 +52,7 @@ class ghostGoogleDrive extends StorageBase {
           version: API_VERSION,
           auth: jwtClient
         });
-        drive.files.create(
+        drive.files.insert(
           {
             resource: {
               title: file.name,
@@ -73,7 +73,7 @@ class ghostGoogleDrive extends StorageBase {
             // make the url looks like a file
             resolve("/content/images/" + data.id + "." + data.fileExtension);
 
-            drive.permissions.create({
+            drive.permissions.insert({
               fileId: data.id,
                 resource: {
                   'type': 'anyone',

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Google drive storage for ghost blog
  * @author : Robin C Samuel <hi@robinz.in> http://robinz.in
  * @date : 11th August 2015
- * @updated: 05th Aug 2017
+ * @updated: 25th Aug 2020 - @BehoyH
  */
 
 const StorageBase = require("ghost-storage-base");
@@ -11,7 +11,7 @@ const fs = require("fs");
 const { google } = require("googleapis");
 const https = require("https");
 
-const API_VERSION = "v2";
+const API_VERSION = "v3";
 const API_SCOPES = ["https://www.googleapis.com/auth/drive"];
 
 class ghostGoogleDrive extends StorageBase {
@@ -31,7 +31,7 @@ class ghostGoogleDrive extends StorageBase {
    */
   save(file, targetDir) {
     const _this = this;
-    return new Promise(function(resolve, reject) {
+    return new Promise(function (resolve, reject) {
       const key = _this.config.key;
       const jwtClient = new google.auth.JWT(
         key.client_email,
@@ -41,7 +41,7 @@ class ghostGoogleDrive extends StorageBase {
         null
       );
 
-      jwtClient.authorize(function(err, tokens) {
+      jwtClient.authorize(function (err, tokens) {
         if (err) {
           console.log(err);
           reject(err);
@@ -63,7 +63,7 @@ class ghostGoogleDrive extends StorageBase {
               body: fs.createReadStream(file.path)
             }
           },
-          function(err, res) {
+          function (err, res) {
             if (err) {
               console.log(err);
               reject(err);
@@ -72,21 +72,15 @@ class ghostGoogleDrive extends StorageBase {
             const { data } = res;
             // make the url looks like a file
             resolve("/content/images/" + data.id + "." + data.fileExtension);
-            
-            var permission = [
-              {
-                'type': 'anyone',
-                'role': 'reader',
-              }
-            ];
-            
+
             drive.permissions.create({
               fileId: data.id,
-              "resource": {
-                resource: permission,
+                resource: {
+                  'type': 'anyone',
+                  'role': 'reader',
+                },
                 fileId: data.id,
                 fields: 'id',
-              }
             }, function (err, res) {
               if (err) {
                 console.error(err);
@@ -126,7 +120,7 @@ class ghostGoogleDrive extends StorageBase {
         null
       );
       //auth
-      jwtClient.authorize(function(err, tokens) {
+      jwtClient.authorize(function (err, tokens) {
         if (err) {
           return next(err);
         }
@@ -138,13 +132,13 @@ class ghostGoogleDrive extends StorageBase {
           {
             fileId: id
           },
-          function(err, response) {
+          function (err, response) {
             if (!err) {
               const file = response.data;
               const newReq = https
                 .request(
                   file.webContentLink + "&access_token=" + tokens.access_token,
-                  function(newRes) {
+                  function (newRes) {
                     // Modify google headers here to cache!
                     const headers = newRes.headers;
                     headers["content-disposition"] =
@@ -157,7 +151,7 @@ class ghostGoogleDrive extends StorageBase {
                     newRes.pipe(res);
                   }
                 )
-                .on("error", function(err) {
+                .on("error", function (err) {
                   console.log(err);
                   res.statusCode = 500;
                   res.end();
@@ -179,7 +173,7 @@ class ghostGoogleDrive extends StorageBase {
    */
   delete() {
     const _this = this;
-    return new Promise(function(resolve, reject) {
+    return new Promise(function (resolve, reject) {
       const key = _this.config.key;
       const jwtClient = new google.auth.JWT(
         key.client_email,
@@ -189,7 +183,7 @@ class ghostGoogleDrive extends StorageBase {
         null
       );
 
-      jwtClient.authorize(function(err, tokens) {
+      jwtClient.authorize(function (err, tokens) {
         if (err) {
           return reject(err);
         }
@@ -201,7 +195,7 @@ class ghostGoogleDrive extends StorageBase {
           {
             fileId: id
           },
-          function(err, data) {
+          function (err, data) {
             if (err) {
               console.log(err);
               return reject(err);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Google drive storage for ghost blog
  * @author : Robin C Samuel <hi@robinz.in> http://robinz.in
  * @date : 11th August 2015
- * @updated: 25th Aug 2020 - @BehoyH
+ * @updated: 25th Aug 2020 - @behoyh
  */
 
 const StorageBase = require("ghost-storage-base");

--- a/index.js
+++ b/index.js
@@ -72,6 +72,18 @@ class ghostGoogleDrive extends StorageBase {
             const { data } = res;
             // make the url looks like a file
             resolve("/content/images/" + data.id + "." + data.fileExtension);
+            
+            drive.permissions.create({
+              "fileId": data.id,
+              "resource": {
+                "role": "reader",
+                "type": "anyone"
+              }
+            })
+            .then(function(response) {
+              console.log("Response", response);
+            },
+            function(err) { console.error("Execute error", err); });
           }
         );
       });

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ class ghostGoogleDrive extends StorageBase {
               const file = response.data;
               const newReq = https
                 .request(
-                  file.downloadUrl + "&access_token=" + tokens.access_token,
+                  file.webContentLink + "&access_token=" + tokens.access_token,
                   function(newRes) {
                     // Modify google headers here to cache!
                     const headers = newRes.headers;
@@ -227,7 +227,7 @@ class ghostGoogleDrive extends StorageBase {
               const file = response.data;
               const req = https
                 .request(
-                  file.downloadUrl + "&access_token=" + tokens.access_token,
+                  file.webContentLink + "&access_token=" + tokens.access_token,
                   res => {
                     let bytes = [];
                     res.on("data", chunk => {

--- a/index.js
+++ b/index.js
@@ -75,12 +75,13 @@ class ghostGoogleDrive extends StorageBase {
 
             drive.permissions.insert({
               fileId: data.id,
-                resource: {
+              supportsAllDrives: true,
+              supportsTeamDrives: true,
+              resource: {
                   'type': 'anyone',
                   'role': 'reader',
-                },
-                fileId: data.id,
-                fields: 'id',
+              },
+              fields: 'id',
             }, function (err, res) {
               if (err) {
                 console.error(err);
@@ -137,7 +138,7 @@ class ghostGoogleDrive extends StorageBase {
               const file = response.data;
               const newReq = https
                 .request(
-                  file.webContentLink + "&access_token=" + tokens.access_token,
+                  file.webContentLink,
                   function (newRes) {
                     // Modify google headers here to cache!
                     const headers = newRes.headers;
@@ -243,7 +244,7 @@ class ghostGoogleDrive extends StorageBase {
               const file = response.data;
               const req = https
                 .request(
-                  file.webContentLink + "&access_token=" + tokens.access_token,
+                  file.webContentLink,
                   res => {
                     let bytes = [];
                     res.on("data", chunk => {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class ghostGoogleDrive extends StorageBase {
           version: API_VERSION,
           auth: jwtClient
         });
-        drive.files.insert(
+        drive.files.create(
           {
             resource: {
               title: file.name,

--- a/index.js
+++ b/index.js
@@ -73,6 +73,13 @@ class ghostGoogleDrive extends StorageBase {
             // make the url looks like a file
             resolve("/content/images/" + data.id + "." + data.fileExtension);
             
+            var permission = [
+              {
+                'type': 'anyone',
+                'role': 'reader',
+              }
+            ];
+            
             drive.permissions.create({
               fileId: data.id,
               "resource": {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class ghostGoogleDrive extends StorageBase {
    */
   save(file, targetDir) {
     const _this = this;
-    return new Promise(function (resolve, reject) {
+    return new Promise(function(resolve, reject) {
       const key = _this.config.key;
       const jwtClient = new google.auth.JWT(
         key.client_email,
@@ -41,7 +41,7 @@ class ghostGoogleDrive extends StorageBase {
         null
       );
 
-      jwtClient.authorize(function (err, tokens) {
+      jwtClient.authorize(function(err, tokens) {
         if (err) {
           console.log(err);
           reject(err);
@@ -63,7 +63,7 @@ class ghostGoogleDrive extends StorageBase {
               body: fs.createReadStream(file.path)
             }
           },
-          function (err, res) {
+          function(err, res) {
             if (err) {
               console.log(err);
               reject(err);
@@ -82,7 +82,7 @@ class ghostGoogleDrive extends StorageBase {
                   'role': 'reader',
               },
               fields: 'id',
-            }, function (err, res) {
+            }, function(err, res) {
               if (err) {
                 console.error(err);
               } else {
@@ -121,7 +121,7 @@ class ghostGoogleDrive extends StorageBase {
         null
       );
       //auth
-      jwtClient.authorize(function (err, tokens) {
+      jwtClient.authorize(function(err, tokens) {
         if (err) {
           return next(err);
         }
@@ -133,13 +133,13 @@ class ghostGoogleDrive extends StorageBase {
           {
             fileId: id
           },
-          function (err, response) {
+          function(err, response) {
             if (!err) {
               const file = response.data;
               const newReq = https
                 .request(
                   file.webContentLink,
-                  function (newRes) {
+                  function(newRes) {
                     // Modify google headers here to cache!
                     const headers = newRes.headers;
                     headers["content-disposition"] =
@@ -152,7 +152,7 @@ class ghostGoogleDrive extends StorageBase {
                     newRes.pipe(res);
                   }
                 )
-                .on("error", function (err) {
+                .on("error", function(err) {
                   console.log(err);
                   res.statusCode = 500;
                   res.end();
@@ -174,7 +174,7 @@ class ghostGoogleDrive extends StorageBase {
    */
   delete() {
     const _this = this;
-    return new Promise(function (resolve, reject) {
+    return new Promise(function(resolve, reject) {
       const key = _this.config.key;
       const jwtClient = new google.auth.JWT(
         key.client_email,
@@ -184,7 +184,7 @@ class ghostGoogleDrive extends StorageBase {
         null
       );
 
-      jwtClient.authorize(function (err, tokens) {
+      jwtClient.authorize(function(err, tokens) {
         if (err) {
           return reject(err);
         }
@@ -196,7 +196,7 @@ class ghostGoogleDrive extends StorageBase {
           {
             fileId: id
           },
-          function (err, data) {
+          function(err, data) {
             if (err) {
               console.log(err);
               return reject(err);

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ class ghostGoogleDrive extends StorageBase {
             // make the url looks like a file
             resolve("/content/images/" + data.id + "." + data.fileExtension);
             
-            drive.permissions.create({
+            drive.files.permissions.create({
               "fileId": data.id,
               "resource": {
                 "role": "reader",


### PR DESCRIPTION
Due to [this issue](https://stackoverflow.com/questions/60214986/google-drive-api-automated-queries-message/60398610#60398610), I patched in a fix for the plugin that uses the `webContentLink` property instead of the `downloadUrl` property. This fixes the Google Drive automated query detection issue on V2.

We should probably consider moving this to V3 of the Drive API, but for now this patch allows images to be saved & viewed without being blocked as suspicious by Google. 

[Test](https://westmichigancopts.org/test/)